### PR TITLE
do not use the path/filepath package

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
-	"path/filepath"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -46,7 +46,7 @@ func AddCommands(fs embed.FS) {
 
 	for _, entry := range entries {
 		cmdName := removerExt(entry.Name())
-		b, err := fs.ReadFile(filepath.Join("fortune", entry.Name()))
+		b, err := fs.ReadFile("fortune/" + entry.Name())
 		if err != nil {
 			exitError(err)
 		}
@@ -63,7 +63,10 @@ func AddCommands(fs embed.FS) {
 }
 
 func removerExt(path string) string {
-	return filepath.Base(path[:len(path)-len(filepath.Ext(path))])
+	if idx := strings.LastIndexByte(path, '.'); idx >= 0 {
+		return path[:idx]
+	}
+	return path
 }
 
 func randomPrint() int {


### PR DESCRIPTION
the `io/fs` package is platform independent, so paths are slash-separated on all systems, even Windows.

> https://pkg.go.dev/io/fs#ValidPath
>
> ValidPath reports whether the given path name is valid for use in a call to Open.
> 
> Path names passed to open are UTF-8-encoded, unrooted, slash-separated sequences of path elements, like “x/y/z”. Path names must not contain an element that is “.” or “..” or the empty string, except for the special case that the root directory is named “.”. Paths must not start or end with a slash: “/x” and “x/” are invalid.
> 
> Note that paths are slash-separated on all systems, even Windows. Paths containing other characters such as backslash and colon are accepted as valid, but those characters must never be interpreted by an FS implementation as path element separators.

On the other hand, the `path/filepath` package is dependent. Paths are slash-separated on unix-like system, but they are backslash-separated on Windows.

> https://pkg.go.dev/path/filepath
>
> Package filepath implements utility routines for manipulating filename paths in a way compatible with the target operating system-defined file paths.
> 
> The filepath package uses either forward slashes or backslashes, depending on the operating system. To process paths such as URLs that always use forward slashes regardless of the operating system, see the path package.

You should not use the `path/filepath` package for handling paths for `fs.FS`.
