### PR TITLE
quote the version of Go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: "1.17"
 
     - name: Build
       run: make build

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: "1.17"
 
     - name: UnitTest
       run: make test


### PR DESCRIPTION
I recommend you to alway quote the version of Go.
Even if it seems to be working now, there may be problems in the future.

According to Go's release cycle, Go 1.20 will be released in February next year.
The configuration file of GitHub Actions is YAML, and YAML parser treats `1.20` as a number.
Many parsers do not distinguish between the numbers `1.20` and `1.2`.
It confuses GitHub Actions.

If you write `"1.20"`, the parsers treat it as a string.
You will not have this problem.
